### PR TITLE
add support for deploying Rackspace Cloud Controller

### DIFF
--- a/kubespray/inventory/sample/group_vars/all/all.yml
+++ b/kubespray/inventory/sample/group_vars/all/all.yml
@@ -51,7 +51,7 @@ cloud_provider: external
 ## When cloud_provider is set to 'external', you can set the cloud controller to deploy
 ## Supported cloud controllers are: 'openstack' and 'vsphere'
 ## When openstack or vsphere are used make sure to source in the required fields
-external_cloud_provider: openstack
+external_cloud_provider: rackspace
 
 ## Set these proxy values in order to update package manager and docker daemon to use proxies
 # http_proxy: ""

--- a/kubespray/inventory/sample/group_vars/all/rackspace.yaml
+++ b/kubespray/inventory/sample/group_vars/all/rackspace.yaml
@@ -1,0 +1,10 @@
+# Cloud Load Balancer Configs
+# rackspace_clb_method: "ROUND_ROBIN"
+# rackspace_clb_create_monitor: "yes"
+# rackspace_clb_monitor_delay: "1m"
+# rackspace_clb_monitor_timeout: "30s"
+# rackspace_clb_monitor_max_retries: "3"
+# rackspace_network_ipv6_disable: false
+
+## The tag of the external Rackspace Cloud Controller image
+# rackspace_cloud_controller_image_tag: "latest"

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/meta/main.yml
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/meta/main.yml
@@ -20,3 +20,13 @@ dependencies:
     tags:
       - external-cloud-controller
       - external-vsphere
+  - role: kubernetes-apps/external_cloud_controller/rackspace
+    when:
+      - cloud_provider is defined
+      - cloud_provider == "external"
+      - external_cloud_provider is defined
+      - external_cloud_provider == "rackspace"
+      - inventory_hostname == groups['kube-master'][0]
+    tags:
+      - external-cloud-controller
+      - rackspace

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/defaults/main.yml
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# The external cloud controller will need credentials to access
+# openstack apis. Per default these values will be
+# read from the environment.
+rackspace_username: "{{ lookup('env','OS_USERNAME')  }}"
+rackspace_password: "{{ lookup('env','OS_PASSWORD')  }}"
+rackspace_region: "{{ lookup('env','OS_REGION_NAME')  }}"
+rackspace_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID'),true) }}"
+
+rackspace_cloud_controller_image_tag: "0.0.0"
+
+rackspace_network_ipv6_disabled: false

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/tasks/main.yml
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- include_tasks: rackspace-credential-check.yml
+  tags: rackspace
+
+- name: Rackspace Cloud Controller | Write Rackspace cloud-config
+  template:
+    src: "rackspace-cloud-config.j2"
+    dest: "{{ kube_config_dir }}/rackspace_cloud_config"
+    group: "{{ kube_cert_group }}"
+    mode: 0640
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: rackspace
+
+- name: Rackspace Cloud Controller | Get base64 cloud-config
+  slurp:
+    src: "{{ kube_config_dir }}/rackspace_cloud_config"
+  register: rackspace_cloud_config_secret
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: rackspace
+
+- name: Rackspace Cloud Controller | Generate Manifests
+  template:
+    src: "{{ item.file }}.j2"
+    dest: "{{ kube_config_dir }}/{{ item.file }}"
+  with_items:
+    - {name: rackspace-cloud-config-secret, file: rackspace-cloud-config-secret.yml}
+    - {name: rackspace-cloud-controller-manager-roles, file: rackspace-cloud-controller-manager-roles.yml}
+    - {name: rackspace-cloud-controller-manager-role-bindings, file: rackspace-cloud-controller-manager-role-bindings.yml}
+    - {name: rackspace-cloud-controller-manager-ds, file: rackspace-cloud-controller-manager-ds.yml}
+  register: rackspace_manifests
+  when: inventory_hostname == groups['kube-master'][0]
+  tags: rackspace
+
+- name: Rackspace Cloud Controller | Apply Manifests
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ kube_config_dir }}/{{ item.item.file }}"
+    state: "latest"
+  with_items:
+    - "{{ rackspace_manifests.results }}"
+  when:
+    - inventory_hostname == groups['kube-master'][0]
+    - not item is skipped
+  loop_control:
+    label: "{{ item.item.file }}"
+  tags: rackspace

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/tasks/rackspace-credential-check.yml
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/tasks/rackspace-credential-check.yml
@@ -1,0 +1,26 @@
+---
+- name: Rackspace Cloud Controller | check rackspace_username
+  fail:
+    msg: "rackspace_username is missing"
+  when:
+    - rackspace_username is not defined or not rackspace_username
+
+
+- name: Rackspace Cloud Controller | check rackspace_password value
+  fail:
+    msg: "rackspace_password is missing"
+  when:
+    - rackspace_password is not defined or not rackspace_password
+
+
+- name: Rackspace Cloud Controller | check rackspace_region value
+  fail:
+    msg: "rackspace_region is missing"
+  when: rackspace_region is not defined or not rackspace_region
+
+
+- name: Rackspace Cloud Controller | check rackspace_tenant_id value
+  fail:
+    msg: "rackspace_tenant_id is missing"
+  when:
+    - rackspace_tenant_id is not defined or not rackspace_tenant_id

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-config-secret.yml.j2
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-config-secret.yml.j2
@@ -1,0 +1,10 @@
+# This YAML file contains secret objects,
+# which are necessary to run external rackspace cloud controller.
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: rackspace-cloud-config
+  namespace: kube-system
+data:
+  cloud.conf: {{ rackspace_cloud_config_secret.content }}

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-config.j2
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-config.j2
@@ -1,0 +1,16 @@
+[Global]
+auth-url="https://identity.api.rackspacecloud.com/v2.0/"
+username="{{ rackspace_username }}"
+password="{{ rackspace_password }}"
+region="{{ rackspace_region }}"
+tenant-id="{{ rackspace_tenant_id }}"
+
+[LoadBalancer]
+
+[Networking]
+ipv6-support-disabled={{ rackspace_network_ipv6_disabled | string | lower }}
+internal-network-name="private"
+public-network-name="public"
+
+[Metadata]
+search-order="configDrive,metadataService"

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-controller-manager-ds.yml.j2
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-controller-manager-ds.yml.j2
@@ -1,0 +1,91 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rackspace-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: rackspace-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: rackspace-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: rackspace-cloud-controller-manager
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 1001
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: rackspace-cloud-controller-manager
+          image: {{ docker_image_repo }}/ospc/rackspace-cloud-controller-manager:{{ rackspace_cloud_controller_image_tag }}
+          args:
+            - --v=1
+            - --cloud-config=$(CLOUD_CONFIG)
+            - --cloud-provider=openstack
+            - --use-service-account-credentials=true
+            - --address=127.0.0.1
+          volumeMounts:
+            - mountPath: /etc/kubernetes/pki
+              name: k8s-certs
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /etc/config
+              name: cloud-config-volume
+              readOnly: true
+            - mountPath: /var/lib/cloud/data
+              name: cloud-init-data
+              readOnly: true
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+            - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+              name: flexvolume-dir
+{% endif %}
+          resources:
+            requests:
+              cpu: 200m
+          env:
+            - name: CLOUD_CONFIG
+              value: /etc/config/cloud.conf
+      hostNetwork: true
+      volumes:
+{% if kubelet_flexvolumes_plugins_dir is defined %}
+      - hostPath:
+          path: "{{ kubelet_flexvolumes_plugins_dir }}"
+          type: DirectoryOrCreate
+        name: flexvolume-dir
+{% endif %}
+      - hostPath:
+          path: /etc/kubernetes/pki
+          type: DirectoryOrCreate
+        name: k8s-certs
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /var/lib/cloud/data
+          type: DirectoryOrCreate
+        name: cloud-init-data
+      - name: cloud-config-volume
+        secret:
+          secretName: rackspace-cloud-config

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-controller-manager-role-bindings.yml.j2
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-controller-manager-role-bindings.yml.j2
@@ -1,0 +1,40 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-node-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-node-controller
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-node-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:pvl-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:pvl-controller
+  subjects:
+  - kind: ServiceAccount
+    name: pvl-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-controller-manager
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-controller-manager
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+kind: List
+metadata: {}

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-controller-manager-roles.yml.j2
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-controller-manager-roles.yml.j2
@@ -1,0 +1,142 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-controller-manager
+  rules:
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - create
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - list
+    - get
+    - watch
+  - apiGroups:
+    - authentication.k8s.io
+    resources:
+    - tokenreviews
+    verbs:
+    - create
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-node-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:pvl-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+kind: List
+metadata: {}

--- a/kubespray/roles/kubespray-defaults/defaults/main.yaml
+++ b/kubespray/roles/kubespray-defaults/defaults/main.yaml
@@ -379,6 +379,10 @@ external_openstack_network_internal_networks:
 external_openstack_network_public_networks:
 - ""
 
+## Enable Rackspace Cloud Controller by default
+cloud_provider: external
+external_cloud_provider: rackspace
+
 ## List of authorization modes that must be configured for
 ## the k8s cluster. Only 'AlwaysAllow', 'AlwaysDeny', 'Node' and
 ## 'RBAC' modes are tested. Order is important.


### PR DESCRIPTION
Support deploying the Rackspace variant of the OpenStack Cloud
Controller. Started with the OpenStack code as a template and made
Rackspace specific changes.