### PR TITLE
switch from password auth to API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ OS_CLOUD=<mycloud> openstack token issue
 ```
 $ export OS_TENANT_ID='nova tenant id / openstack project_id'
 $ export OS_USERNAME='nova username'
-$ export OS_PASSWORD='user passwd'  # temporarily required for the cloud provider acct must not have 2FA
+$ export RAX_API_KEY='api key for user'
 $ export OS_AUTH_TOKEN='token id'
 $ export OS_REGION_NAME='YOURPICK'  # DFW, IAD, ORD, LON, SYD, HKG
 ```

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/defaults/main.yml
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/defaults/main.yml
@@ -3,10 +3,10 @@
 # openstack apis. Per default these values will be
 # read from the environment.
 rackspace_username: "{{ lookup('env','OS_USERNAME')  }}"
-rackspace_password: "{{ lookup('env','OS_PASSWORD')  }}"
+rackspace_api_key: "{{ lookup('env','RAX_API_KEY')  }}"
 rackspace_region: "{{ lookup('env','OS_REGION_NAME')  }}"
 rackspace_tenant_id: "{{ lookup('env','OS_TENANT_ID')| default(lookup('env','OS_PROJECT_ID'),true) }}"
 
-rackspace_cloud_controller_image_tag: "0.0.0"
+rackspace_cloud_controller_image_tag: "0.0.1"
 
 rackspace_network_ipv6_disabled: false

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/tasks/rackspace-credential-check.yml
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/tasks/rackspace-credential-check.yml
@@ -1,26 +1,26 @@
 ---
 - name: Rackspace Cloud Controller | check rackspace_username
   fail:
-    msg: "rackspace_username is missing"
+    msg: "rackspace_username is missing (OS_USERNAME)"
   when:
     - rackspace_username is not defined or not rackspace_username
 
 
-- name: Rackspace Cloud Controller | check rackspace_password value
+- name: Rackspace Cloud Controller | check rackspace_api_key value
   fail:
-    msg: "rackspace_password is missing"
+    msg: "rackspace_api_key is missing (RAX_API_KEY)"
   when:
-    - rackspace_password is not defined or not rackspace_password
+    - rackspace_api_key is not defined or not rackspace_api_key
 
 
 - name: Rackspace Cloud Controller | check rackspace_region value
   fail:
-    msg: "rackspace_region is missing"
+    msg: "rackspace_region is missing (OS_REGION_NAME)"
   when: rackspace_region is not defined or not rackspace_region
 
 
 - name: Rackspace Cloud Controller | check rackspace_tenant_id value
   fail:
-    msg: "rackspace_tenant_id is missing"
+    msg: "rackspace_tenant_id is missing (OS_TENANT_ID)"
   when:
     - rackspace_tenant_id is not defined or not rackspace_tenant_id

--- a/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-config.j2
+++ b/kubespray/roles/kubernetes-apps/external_cloud_controller/rackspace/templates/rackspace-cloud-config.j2
@@ -1,7 +1,7 @@
 [Global]
 auth-url="https://identity.api.rackspacecloud.com/v2.0/"
 username="{{ rackspace_username }}"
-password="{{ rackspace_password }}"
+rax-api-key="{{ rackspace_api_key }}"
 region="{{ rackspace_region }}"
 tenant-id="{{ rackspace_tenant_id }}"
 


### PR DESCRIPTION
Switched the controller to using the password to authenticate to using the API key for authentication. This should solve the issue where 2FA is enabled on some accounts and we need to use an API key to authenticate programmatically.